### PR TITLE
Fix minor docstring error

### DIFF
--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -98,7 +98,7 @@ class JWTManager:
 
     def user_identity_loader(self, callback):
         """
-        This sets the callback method for adding custom identities claims to a JWT.
+        This sets the callback method for adding custom user identities to a JWT.
 
         By default, no extra user identities will be added to the JWT.
 

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -98,9 +98,9 @@ class JWTManager:
 
     def user_identity_loader(self, callback):
         """
-        This sets the callback method for adding custom user claims to a JWT.
+        This sets the callback method for adding custom identities claims to a JWT.
 
-        By default, no extra user claims will be added to the JWT.
+        By default, no extra user identities will be added to the JWT.
 
         Callback must be a function that takes only one argument, which is the
         identity of the JWT being created.


### PR DESCRIPTION
The docstring refers incorrectly to user_claims when it really refers to user_identity